### PR TITLE
Add `parseDateLiteral` helper

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -51,6 +51,7 @@ module.exports = (function () {
       // Shim in required query params and parse any logical operators.
       options.where = queryShim(options.where, collectionName)
       options.where = parseClause(options.where)
+      options.where = parseDateLiterals(options.where);
 
       spawnConnection(connectionName)
         .then(function(connection) {
@@ -223,6 +224,18 @@ module.exports = (function () {
       obj[key] = val
 
       return obj
+    }, {}, original)
+  }
+
+  function parseDateLiterals(original) {
+    return _.reduce(original, function(obj, val, key) {
+      if (key.indexOf('Date') != -1) {
+        obj[key] = jsforce.Date[val] ||
+          jsforce.SfDate.toDateTimeLiteral(jsforce.SfDate.parseDate(data[key]));
+      } else {
+        obj[key] = val;
+      }
+      return obj;
     }, {}, original)
   }
 


### PR DESCRIPTION
Adds basic `parseDateLiteral` helper method to enable the usage of
SalesForce date literals in queries, such as `THIS_YEAR`.
